### PR TITLE
Fixed malformed JSON during export to paprika

### DIFF
--- a/kptncook/paprika.py
+++ b/kptncook/paprika.py
@@ -33,7 +33,7 @@ PAPRIKA_RECIPE_TEMPLATE = """{
    "servings":"2",
    "rating":0,
    "difficulty":"",
-   "ingredients":"{% for ingredient in recipe.ingredients %}{% if ingredient.quantity %}{{'{0:g}'.format(ingredient.quantity) }}{% endif %} {{ingredient.measure|default('',true)}} {{ingredient.ingredient.uncountable_title.de|default('',true)}}\n{% endfor %}",
+   "ingredients":"{% for ingredient in recipe.ingredients %}{% if ingredient.quantity %}{{'{0:g}'.format(ingredient.quantity) }}{% endif %} {{ingredient.measure|default('',true)}} {{ingredient.ingredient.uncountable_title.de|default('',true)}}\\n{% endfor %}",
    "notes":"",
    "created":"{{dtnow}}",
    "image_url":null,


### PR DESCRIPTION
There was a `\` missing to escape the `\n` in the in the export template for `.paprikarecipes` files.

My guess is that this bug was introduced with a00e426da87fc271622ad4a40f4e002d2096627e when moving the template file to `kptncook/paprika.py`