### PR TITLE
Not adding title to each ingredient in recipe

### DIFF
--- a/kptncook/mealie.py
+++ b/kptncook/mealie.py
@@ -397,7 +397,7 @@ def kptncook_to_mealie_ingredients(kptncook_ingredients):
             if ingredient.measure is not None:
                 measure = {"name": ingredient.measure}
         mealie_ingredient = RecipeIngredient(
-            title=title, quantity=quantity, unit=measure, note=note, food=food
+            title=None, quantity=quantity, unit=measure, note=note, food=food
         )
         mealie_ingredients.append(mealie_ingredient)
     return mealie_ingredients


### PR DESCRIPTION
This PR just removes the title above each ingredient as the titles are more as subheadings for ingredient-sections. Also already mentioned in #38 
Before:
![Screenshot 2024-12-28 154539](https://github.com/user-attachments/assets/af371fc4-ba79-4db8-8328-a66890f5e96e)

After:
![Screenshot 2024-12-28 154513](https://github.com/user-attachments/assets/8397bd51-e7be-4c6d-9686-b78e9bbd0c86)
