### PR TITLE
Fix nutrition

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,5 @@
 [flake8]
 ignore = D203,W503
+extend-ignore = E701
 exclude = .git,__pycache__,build,dist
 max-line-length = 119

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,10 @@ repos:
       - id: pyupgrade
         args: [--py310-plus]
   - repo: https://github.com/psf/black
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black
-        language_version: python3.11
-
+        language_version: python3.13
   - repo: https://github.com/timothycrosley/isort
     # isort config is in setup.cfg
     rev: 5.13.2

--- a/kptncook/mealie.py
+++ b/kptncook/mealie.py
@@ -108,13 +108,13 @@ class RecipeStep(BaseModel):
 
 
 class Nutrition(BaseModel):
-    calories: str | int | None = None
-    fat_content: str | None = None
-    protein_content: str | None = None
-    carbohydrate_content: str | None = None
-    fiber_content: str | None = None
-    sodium_content: str | None = None
-    sugar_content: str | None = None
+    calories: str | None = None
+    fatContent: str | None = None
+    proteinContent: str | None = None
+    carbohydrateContent: str | None = None
+    fiberContent: str | None = None
+    sodiumContent: str | None = None
+    sugarContent: str | None = None
 
 
 class RecipeSettings(BaseModel):
@@ -421,11 +421,11 @@ def kptncook_to_mealie(
             RecipeNote(title="author comment", text=kcin.author_comment.de),
         ],
         "nutrition": Nutrition(
-            calories=kcin.recipe_nutrition.calories,
-            proteinContent=kcin.recipe_nutrition.protein,
-            fatContent=kcin.recipe_nutrition.fat,
-            carbohydrateContent=kcin.recipe_nutrition.carbohydrate,
-        ),  # type: ignore
+            calories=str(kcin.recipe_nutrition.calories),
+            proteinContent=str(kcin.recipe_nutrition.protein),
+            fatContent=str(kcin.recipe_nutrition.fat),
+            carbohydrateContent=str(kcin.recipe_nutrition.carbohydrate),
+        ),
         "prep_time": kcin.preparation_time,
         "cook_time": kcin.cooking_time,
         "recipe_yield": "1 Portionen",

--- a/kptncook/mealie.py
+++ b/kptncook/mealie.py
@@ -52,8 +52,7 @@ class UnitFoodBase(NameIsIdModel):
     description: str = ""
 
 
-class RecipeFood(UnitFoodBase):
-    ...
+class RecipeFood(UnitFoodBase): ...
 
 
 class RecipeUnit(UnitFoodBase):
@@ -230,7 +229,7 @@ class MealieApiClient:
             instruction.text = self._build_recipestep_text(
                 recipe.id, instruction.text, uploaded_image_name
             )
-            assets.append(RecipeAsset(name=asset_properties["name"], icon=asset_properties["icon"], file_name=asset_properties["fileName"]))
+            assets.append(RecipeAsset(name=asset_properties["name"], icon=asset_properties["icon"], file_name=asset_properties["fileName"]))  # fmt: skip  # noqa: E501
         recipe.assets = assets
         return recipe
 

--- a/tests/to_mealie_test.py
+++ b/tests/to_mealie_test.py
@@ -11,3 +11,12 @@ def test_parse_full_recipe(full_recipe):
     assert mealie_recipe.extras is not None
     assert "kptncook_id" in mealie_recipe.extras
     assert mealie_recipe.extras["source"] == "kptncook"
+
+    assert mealie_recipe.nutrition is not None
+    assert mealie_recipe.nutrition.calories == "900"
+    assert mealie_recipe.nutrition.fatContent == "41"
+    assert mealie_recipe.nutrition.proteinContent == "40"
+    assert mealie_recipe.nutrition.carbohydrateContent == "85"
+    assert mealie_recipe.nutrition.fiberContent is None
+    assert mealie_recipe.nutrition.sodiumContent is None
+    assert mealie_recipe.nutrition.sugarContent is None


### PR DESCRIPTION
Fix nutrition import into Mealie by matching their API spec:
```json
"nutrition": {
    "calories": "string",
    "carbohydrateContent": "string",
    "cholesterolContent": "string",
    "fatContent": "string",
    "fiberContent": "string",
    "proteinContent": "string",
    "saturatedFatContent": "string",
    "sodiumContent": "string",
    "sugarContent": "string",
    "transFatContent": "string",
    "unsaturatedFatContent": "string"
}
```