### PR TITLE
support for <timer> in recipes

### DIFF
--- a/src/kptncook/mealie.py
+++ b/src/kptncook/mealie.py
@@ -12,6 +12,7 @@ from pydantic import UUID4, BaseModel, ConfigDict, Field, ValidationError, parse
 
 from .config import settings
 from .ingredient_groups import iter_ingredient_groups
+from .exporter_utils import get_step_text
 from .models import (
     Image,
     Ingredient,
@@ -493,7 +494,7 @@ def kptncook_to_mealie_steps(
         mealie_instructions.append(
             RecipeStep(
                 title=None,
-                text=localized_fallback(step.title) or "",
+                text=get_step_text(step),
                 image=image,
                 ingredientReferences=ingredient_references,
             )

--- a/src/kptncook/models.py
+++ b/src/kptncook/models.py
@@ -187,10 +187,22 @@ class StepIngredient(BaseModel):
         return values
 
 
+class StepTimer(BaseModel):
+    """Timer for a recipe step. Times are in minutes."""
+
+    model_config = ConfigDict(
+        alias_generator=to_camel, extra="ignore", populate_by_name=True
+    )
+
+    min_or_exact: int | None = None
+    max: int | None = None
+
+
 class RecipeStep(BaseModel):
     title: LocalizedString
     image: Image
     ingredients: list[StepIngredient | None] | None = None
+    timers: list[StepTimer] | None = None
 
 
 class Recipe(BaseModel):

--- a/src/kptncook/paprika.py
+++ b/src/kptncook/paprika.py
@@ -27,6 +27,7 @@ from kptncook.config import settings
 from kptncook.exporter_utils import (
     asciify_string,
     get_cover,
+    get_step_text,
     move_to_target_dir,
     write_zip,
 )
@@ -36,7 +37,7 @@ from kptncook.models import Image, Ingredient, Recipe, localized_fallback
 PAPRIKA_RECIPE_TEMPLATE = """{
    "uid":"{{recipe.id.oid}}",
    "name":"{{localized_fallback(recipe.localized_title)|default('',true)}}",
-   "directions": "{% for step in recipe.steps %}{{localized_fallback(step.title)|default('',true)}}\\n{% endfor %}",
+   "directions": "{% for step in recipe.steps %}{{get_step_text(step)|default('',true)}}\\n{% endfor %}",
    "servings":"2",
    "rating":0,
    "difficulty":"",
@@ -115,6 +116,7 @@ class PaprikaExporter:
         recipe_as_json = self.template.render(
             recipe=recipe,
             localized_fallback=localized_fallback,
+            get_step_text=get_step_text,
             dtnow=generated.dtnow,
             cover_filename=generated.cover_filename,
             hash=generated.hash,
@@ -142,7 +144,7 @@ class PaprikaExporter:
     def format_ingredient_line(self, ingredient: Ingredient) -> str:
         parts: list[str] = []
         if ingredient.quantity:
-            parts.append("{0:g}".format(ingredient.quantity))
+            parts.append(f"{ingredient.quantity:g}")
         if ingredient.measure:
             parts.append(ingredient.measure)
         ingredient_name = (

--- a/src/kptncook/tandoor.py
+++ b/src/kptncook/tandoor.py
@@ -16,6 +16,7 @@ from kptncook.config import settings
 from kptncook.exporter_utils import (
     asciify_string,
     get_cover,
+    get_step_text,
     move_to_target_dir,
     write_zip,
     ZipContent,
@@ -127,7 +128,7 @@ class TandoorExporter:
         for step in recipe.steps:
             steps.append(
                 {
-                    "instruction": localized_fallback(step.title) or "",
+                    "instruction": get_step_text(step),
                     "ingredients": self.get_step_ingredients(step=step),
                 }
             )

--- a/tests/exporter_utils_test.py
+++ b/tests/exporter_utils_test.py
@@ -1,0 +1,83 @@
+from kptncook.exporter_utils import (
+    expand_timer_placeholders,
+    format_timer,
+    get_step_text,
+)
+from kptncook.models import Image, LocalizedString, RecipeStep, StepTimer
+
+
+class TestFormatTimer:
+    def test_min_or_exact_only_default_german(self):
+        assert format_timer(StepTimer(min_or_exact=15)) == "15 Min."
+
+    def test_min_or_exact_and_max_default_german(self):
+        assert format_timer(StepTimer(min_or_exact=30, max=40)) == "30–40 Min."
+
+    def test_max_only_default_german(self):
+        assert format_timer(StepTimer(max=20)) == "bis zu 20 Min."
+
+    def test_empty_returns_empty_string(self):
+        assert format_timer(StepTimer()) == ""
+
+
+class TestExpandTimerPlaceholders:
+    def test_single_placeholder(self):
+        text = "Cook for ca. <timer> until done."
+        timers = [StepTimer(min_or_exact=15)]
+        assert (
+            expand_timer_placeholders(text, timers)
+            == "Cook for ca. 15 Min. until done."
+        )
+
+    def test_multiple_placeholders(self):
+        text = "Fry <timer>, then simmer <timer>."
+        timers = [
+            StepTimer(min_or_exact=3),
+            StepTimer(min_or_exact=20, max=30),
+        ]
+        assert (
+            expand_timer_placeholders(text, timers)
+            == "Fry 3 Min., then simmer 20–30 Min.."
+        )
+
+    def test_no_placeholders_unchanged(self):
+        text = "Just add salt."
+        timers = [StepTimer(min_or_exact=5)]
+        assert expand_timer_placeholders(text, timers) == "Just add salt."
+
+    def test_no_timers_strips_placeholder(self):
+        text = "Cook <timer> and serve."
+        assert expand_timer_placeholders(text, None) == "Cook  and serve."
+        assert expand_timer_placeholders(text, []) == "Cook  and serve."
+
+    def test_more_placeholders_than_timers(self):
+        text = "<timer> and <timer> and <timer>"
+        timers = [StepTimer(min_or_exact=1), StepTimer(min_or_exact=2)]
+        assert expand_timer_placeholders(text, timers) == "1 Min. and 2 Min. and "
+
+    def test_empty_text(self):
+        assert expand_timer_placeholders("", [StepTimer(min_or_exact=5)]) == ""
+
+
+class TestGetStepText:
+    def test_step_with_timer_expands_placeholder(self):
+        step = RecipeStep(
+            title=LocalizedString(de="Kartoffeln ca. <timer> kochen."),
+            image=Image(name="x.jpg", url="https://example.com/x.jpg"),
+            timers=[StepTimer(min_or_exact=15)],
+        )
+        assert get_step_text(step) == "Kartoffeln ca. 15 Min. kochen."
+
+    def test_step_without_timers_strips_placeholder(self):
+        step = RecipeStep(
+            title=LocalizedString(de="Cook <timer> and serve."),
+            image=Image(name="x.jpg", url="https://example.com/x.jpg"),
+        )
+        assert get_step_text(step) == "Cook  and serve."
+
+    def test_step_old_format_no_placeholder(self):
+        step = RecipeStep(
+            title=LocalizedString(de="Ca. 2-3 min. braten."),
+            image=Image(name="x.jpg", url="https://example.com/x.jpg"),
+        )
+        assert get_step_text(step) == "Ca. 2-3 min. braten."

--- a/tests/to_mealie_test.py
+++ b/tests/to_mealie_test.py
@@ -101,3 +101,23 @@ def test_mealie_export_handles_duplicate_ingredient_ids(minimal):
     assert len(ingredient_reference_ids) == 2
     assert len(set(ingredient_reference_ids)) == 2
     assert set(step_reference_ids) == set(ingredient_reference_ids)
+
+
+def test_mealie_export_expands_timer_placeholders(minimal):
+    recipe_data = {
+        **minimal,
+        "steps": [
+            {
+                "title": {"de": "Kartoffeln ca. <timer> in Wasser kochen."},
+                "ingredients": [],
+                "image": minimal["steps"][0]["image"],
+                "timers": [{"minOrExact": 15}],
+            }
+        ],
+    }
+    kc_recipe = Recipe.model_validate(recipe_data)
+    mealie_recipe = kptncook_to_mealie(kc_recipe)
+
+    step_text = mealie_recipe.recipe_instructions[0].text
+    assert "15 Min." in step_text
+    assert "<timer>" not in step_text


### PR DESCRIPTION
Steps can now carry a separate `timers` array and use <timer> placeholders in the text instead of inline times. Add StepTimer model and format_timer/expand_timer_placeholders/get_step_text helpers, wire them into Mealie, Tandoor, and Paprika exporters. Timer output uses German (15 Min., 30–40 Min., bis zu 20 Min.). Old recipes without timers remain unchanged.

(This is admittedly vibe-coded, and I don't know much about Python. I've got experience in other languages, though, and from that perspective it looks generally fine.)