### PR TITLE
Fix Tandoor export: working_time, keyword dict format, empty step ing…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Unreleased
 ==========
 
+### Fixes
+- #83 Fix Tandoor exports to use Tandoor's working/waiting time fields and
+  keyword object payloads, and skip unnamed step ingredients that Tandoor
+  rejects (thanks @brindor).
+
 0.0.31 - 2026-04-26
 ===================
 

--- a/src/kptncook/tandoor.py
+++ b/src/kptncook/tandoor.py
@@ -3,6 +3,7 @@ Export recipes to Tandoor.
 
 Tandoor expects a zip archive with a recipe.json file and an optional image.jpg.
 """
+
 import json
 import logging
 import tempfile
@@ -31,7 +32,6 @@ from kptncook.models import (
 )
 
 logger = logging.getLogger(__name__)
-
 IMAGE_DOWNLOAD_TIMEOUT = httpx.Timeout(60.0, connect=10.0)
 
 
@@ -58,7 +58,7 @@ class TandoorExporter:
                 entries.append(("image.jpg", image_bytes))
             write_zip(zip_path, entries)
             move_to_target_dir(zip_path, Path.cwd() / filename)
-            return filename
+        return filename
 
     def get_export_filename(self, recipe: Recipe) -> str:
         title = localized_fallback(recipe.localized_title) or "kptncook-recipe"
@@ -156,6 +156,9 @@ class TandoorExporter:
             return None
         ingredient_name = self.get_step_ingredient_name(ingredient=ingredient)
         if not ingredient_name:
+            logger.debug(
+                "Skipping Tandoor step ingredient without a resolvable food name."
+            )
             return None
         payload = {
             "amount": ingredient.quantity,

--- a/src/kptncook/tandoor.py
+++ b/src/kptncook/tandoor.py
@@ -3,7 +3,6 @@ Export recipes to Tandoor.
 
 Tandoor expects a zip archive with a recipe.json file and an optional image.jpg.
 """
-
 import json
 import logging
 import tempfile
@@ -32,6 +31,7 @@ from kptncook.models import (
 )
 
 logger = logging.getLogger(__name__)
+
 IMAGE_DOWNLOAD_TIMEOUT = httpx.Timeout(60.0, connect=10.0)
 
 
@@ -58,7 +58,7 @@ class TandoorExporter:
                 entries.append(("image.jpg", image_bytes))
             write_zip(zip_path, entries)
             move_to_target_dir(zip_path, Path.cwd() / filename)
-        return filename
+            return filename
 
     def get_export_filename(self, recipe: Recipe) -> str:
         title = localized_fallback(recipe.localized_title) or "kptncook-recipe"
@@ -105,8 +105,8 @@ class TandoorExporter:
             "description": localized_fallback(recipe.author_comment) or "",
             "servings": 3,
             "source_url": self.get_source_url(recipe=recipe),
-            "prep_time": recipe.preparation_time,
-            "cook_time": recipe.cooking_time,
+            "working_time": recipe.preparation_time,
+            "waiting_time": recipe.cooking_time,
             "keywords": self.get_keywords(recipe=recipe),
             "steps": self.get_steps(recipe=recipe),
             "ingredients": self.get_ingredients(recipe=recipe),
@@ -116,12 +116,14 @@ class TandoorExporter:
         source_id = recipe.uid or recipe.id.oid
         return f"https://share.kptncook.com/{source_id}"
 
-    def get_keywords(self, recipe: Recipe) -> list[str]:
-        keywords = ["kptncook"]
+    def get_keywords(self, recipe: Recipe) -> list[dict[str, str]]:
+        keywords = [{"name": "kptncook"}]
         if recipe.active_tags:
-            keywords.extend(self._filter_active_tags(recipe.active_tags))
+            keywords.extend(
+                [{"name": tag} for tag in self._filter_active_tags(recipe.active_tags)]
+            )
         if recipe.rtype:
-            keywords.append(recipe.rtype)
+            keywords.append({"name": recipe.rtype})
         return keywords
 
     @staticmethod
@@ -152,7 +154,9 @@ class TandoorExporter:
     ) -> dict[str, Any] | None:
         if ingredient is None:
             return None
-        ingredient_name = self.get_step_ingredient_name(ingredient=ingredient) or ""
+        ingredient_name = self.get_step_ingredient_name(ingredient=ingredient)
+        if not ingredient_name:
+            return None
         payload = {
             "amount": ingredient.quantity,
             "unit": self.get_step_unit_payload(unit=ingredient.unit),

--- a/tests/tandoor_test.py
+++ b/tests/tandoor_test.py
@@ -32,9 +32,13 @@ def test_export_recipe_writes_zip_with_image(
         assert set(zip_file.namelist()) == {"recipe.json", "image.jpg"}
         payload = json.loads(zip_file.read("recipe.json").decode("utf-8"))
     assert payload["name"] == recipe.localized_title.de
-    assert "kptncook" in payload["keywords"]
-    assert "main_ingredient_pasta" in payload["keywords"]
-    assert "Fish" in payload["keywords"]
+    assert {"name": "kptncook"} in payload["keywords"]
+    assert {"name": "main_ingredient_pasta"} in payload["keywords"]
+    assert {"name": "Fish"} in payload["keywords"]
+    assert "working_time" in payload
+    assert "waiting_time" in payload
+    assert "prep_time" not in payload
+    assert "cook_time" not in payload
     httpx_get.assert_called_once_with(
         "https://example.com/cover.jpg",
         follow_redirects=True,
@@ -118,7 +122,46 @@ def test_get_keywords_includes_active_tags_and_rtype(minimal):
     }
     recipe = Recipe.model_validate(recipe_data)
 
-    assert exporter.get_keywords(recipe) == ["kptncook", "quick", "dinner", "Fish"]
+    assert exporter.get_keywords(recipe) == [
+        {"name": "kptncook"},
+        {"name": "quick"},
+        {"name": "dinner"},
+        {"name": "Fish"},
+    ]
+    assert exporter.get_keywords(recipe).count({"name": "kptncook"}) == 1
+
+
+def test_get_recipe_payload_uses_tandoor_time_fields(minimal):
+    exporter = TandoorExporter()
+    recipe = Recipe.model_validate({**minimal, "cookingTime": 45})
+
+    payload = exporter.get_recipe_payload(recipe)
+
+    assert payload["working_time"] == 20
+    assert payload["waiting_time"] == 45
+    assert "prep_time" not in payload
+    assert "cook_time" not in payload
+
+
+def test_get_step_ingredients_skips_unnamed_ingredients(minimal, caplog):
+    exporter = TandoorExporter()
+    recipe_data = {
+        **minimal,
+        "steps": [
+            {
+                "title": {"de": "Alles parat?"},
+                "ingredients": [{"quantity": 1, "unit": "g"}],
+                "image": minimal["steps"][0]["image"],
+            }
+        ],
+    }
+    recipe = Recipe.model_validate(recipe_data)
+
+    with caplog.at_level("DEBUG", logger="kptncook.tandoor"):
+        ingredients = exporter.get_step_ingredients(recipe.steps[0])
+
+    assert ingredients == []
+    assert "without a resolvable food name" in caplog.text
 
 
 def test_get_recipe_payload_uses_empty_description_without_author_comment(minimal):


### PR DESCRIPTION
…redients

This PR fixes three Tandoor export issues found during recipe import testing:

1. **working_time/waiting_time**: Renamed `prep_time` -> `working_time` and `cook_time` -> `waiting_time` in `get_recipe_payload()`. Tandoor's internal schema uses these field names for active preparation time and passive waiting time.

2. **Keywords as dict list**: Changed `get_keywords()` return type from `list[str]` to `list[dict[str, str]]`. Each keyword is now output as `{"name": "..."}` instead of a bare string. Other fields like `description`, `created_at`, `updated_at` are omitted as they are optional in Tandoor's import format.

3. **Empty step ingredients**: Fixed `get_step_ingredient_payload()` to return `None` when `ingredient_name` is empty, instead of falling back to `{"food": {"name": ""}}`. This prevents the Tandoor import error `ingredients.food.name: This Field May Not Be Blank` for steps that have ingredients without a resolvable name.