### PR TITLE
Fix Docker setup reachability and .env location (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Unreleased
 ==========
 
+### Fixes
+- #87 Make guided setup reachable from the Docker entrypoint by exposing it as
+  the `kptncook setup` subcommand (the standalone `kptncook-setup` command still
+  works), and update the missing-configuration message to point at it.
+- #87 Honor `KPTNCOOK_HOME` when locating the `.env` file so the config is read
+  from and written to the same directory as the rest of kptncook's data. In the
+  Docker image (`KPTNCOOK_HOME=/data`) the `.env` now lives in the mounted
+  volume instead of an ephemeral `~/.kptncook/.env`.
+
 0.0.33 - 2026-06-02
 ===================
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ $ docker build -t kptncook .
 ```
 
 The container sets `KPTNCOOK_HOME=/data`. Mount that directory and provide the
-required environment variables. For Mealie auth, set `MEALIE_API_TOKEN` or
+required environment variables. Passing configuration with `-e` is the
+recommended approach for Docker: it avoids the need for an interactive setup and
+works the same on every run. For Mealie auth, set `MEALIE_API_TOKEN` or
 `MEALIE_USERNAME`/`MEALIE_PASSWORD`:
 
 ```shell
@@ -61,6 +63,19 @@ $ docker run --rm -v ~/.kptncook:/data \
     -e MEALIE_PASSWORD=pass \
     kptncook backup-favorites
 ```
+
+The guided setup is available as the `kptncook setup` subcommand, so it is
+reachable through the container's `kptncook` entrypoint. Because it prompts for
+your KptnCook account credentials, run it with an interactive TTY (`-it`). The
+`.env` it writes lives at `$KPTNCOOK_HOME/.env` (i.e. `/data/.env`), so the
+mounted volume persists it across runs:
+
+```shell
+$ docker run --rm -it -v ~/.kptncook:/data kptncook setup
+```
+
+To fetch only the access token after the API key is already configured, use
+`docker run --rm -it -v ~/.kptncook:/data kptncook kptncook-access-token`.
 
 # Usage
 
@@ -227,11 +242,17 @@ $ touch ~/.kptncook/.env
 ```
 
 Alternatively, you can run the setup helper to create the `.env` file, prefill the
-default API key, and optionally fetch an access token:
+default API key, and optionally fetch an access token. It is available both as a
+`kptncook` subcommand and as a standalone command:
 
 ```shell
+$ kptncook setup
+# or, equivalently:
 $ kptncook-setup
 ```
+
+The `.env` is written to `$KPTNCOOK_HOME/.env` when `KPTNCOOK_HOME` is set,
+otherwise to `~/.kptncook/.env`.
 
 Configuration is validated lazily. If you run a command before configuring the
 API key, kptncook will scaffold the `.env` file when that command first needs

--- a/src/kptncook/cli.py
+++ b/src/kptncook/cli.py
@@ -45,8 +45,14 @@ from kptncook.services.workflows import (
     search_recipe_by_id as search_recipe_by_id_workflow,
     sync_with_mealie_result as sync_with_mealie_workflow,
 )
+from kptncook.setup import setup as setup_command
 
 app = typer.Typer()
+
+# Expose the standalone `kptncook-setup` entry point as a subcommand so guided
+# setup is reachable through the Docker entrypoint (`docker run ... kptncook
+# setup`), where only `kptncook` subcommands can be invoked.
+app.command(name="setup")(setup_command)
 P = ParamSpec("P")
 T = TypeVar("T")
 

--- a/src/kptncook/config.py
+++ b/src/kptncook/config.py
@@ -60,7 +60,7 @@ def render_settings_error(error: SettingsError) -> None:
         rprint("Add your KptnCook API key to the .env file or your shell:")
         rprint(f"  {error.env_path}")
         rprint("  KPTNCOOK_API_KEY=your-api-key-here")
-        rprint("Then re-run the command, or use `kptncook-setup` for guided setup.")
+        rprint("Then re-run the command, or use `kptncook setup` for guided setup.")
         rprint("See README.md for details.")
         return
 

--- a/src/kptncook/env.py
+++ b/src/kptncook/env.py
@@ -4,11 +4,28 @@ Environment configuration helpers for kptncook.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 DEFAULT_API_KEY = "6q7QNKy-oIgk-IMuWisJ-jfN7s6"
 ENV_FILE_MODE = 0o600
-ENV_PATH = Path.home() / ".kptncook" / ".env"
+
+
+def _default_env_dir() -> Path:
+    """Resolve the directory that holds the ``.env`` file.
+
+    Honors ``KPTNCOOK_HOME`` so the config file lands in the same directory as
+    the rest of kptncook's data (matching ``Settings.root``). This keeps the
+    scaffolded ``.env`` and the file the app reads in sync, e.g. inside the
+    Docker image where ``KPTNCOOK_HOME=/data`` is the mounted volume.
+    """
+    home = os.environ.get("KPTNCOOK_HOME")
+    if home:
+        return Path(os.path.expandvars(home)).expanduser()
+    return Path.home() / ".kptncook"
+
+
+ENV_PATH = _default_env_dir() / ".env"
 ENV_TEMPLATE = f"""# kptncook configuration
 #
 # Required

--- a/src/kptncook/setup.py
+++ b/src/kptncook/setup.py
@@ -1,0 +1,128 @@
+"""
+Guided setup command for first-run configuration.
+
+This lives in the ``kptncook`` package (rather than in ``kptncook_setup``) so the
+main CLI can register it as the ``kptncook setup`` subcommand without an import
+cycle. ``kptncook_setup`` re-exports from here, so the dependency only points one
+way: ``kptncook_setup`` -> ``kptncook.setup``, never back.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import httpx
+import typer
+from rich import print as rprint
+
+from kptncook.api import KptnCookClient
+from kptncook.env import (
+    DEFAULT_API_KEY,
+    ENV_PATH,
+    ENV_TEMPLATE,
+    read_env_values,
+    scaffold_env_file,
+    upsert_env_value,
+)
+from kptncook.http_errors import extract_http_error_message, format_request_error
+from kptncook.password_manager import get_credentials
+
+DEFAULT_API_URL = "https://mobile.kptncook.com"
+__all__ = ["ENV_PATH", "ENV_TEMPLATE", "cli", "setup"]
+
+cli = typer.Typer()
+
+
+def _fetch_access_token(api_key: str, username: str, password: str) -> str:
+    client = KptnCookClient(
+        base_url=DEFAULT_API_URL, api_key=api_key, access_token=None
+    )
+    return client.get_access_token(username, password)
+
+
+@cli.command()
+def setup(
+    env_path: Path = typer.Option(
+        ENV_PATH, "--env-path", help="Path to the .env file to configure."
+    ),
+    api_key: str | None = typer.Option(
+        None,
+        "--api-key",
+        help="KptnCook API key (defaults to the value documented in README.md).",
+    ),
+    username_command: str | None = typer.Option(
+        None,
+        "--username-command",
+        help="Command to retrieve username from a password manager.",
+    ),
+    password_command: str | None = typer.Option(
+        None,
+        "--password-command",
+        help="Command to retrieve password from a password manager.",
+    ),
+    fetch_access_token: bool = typer.Option(
+        True,
+        "--fetch-access-token/--no-fetch-access-token",
+        help="Prompt for credentials and fetch an access token.",
+    ),
+) -> None:
+    """
+    Interactive setup for kptncook configuration.
+    """
+    scaffolded = scaffold_env_file(env_path)
+    if scaffolded:
+        rprint(f"Created {env_path} with a starter template.")
+
+    values = read_env_values(env_path)
+    existing_api_key = values.get("KPTNCOOK_API_KEY", "").strip()
+    if not existing_api_key:
+        chosen_key = api_key or DEFAULT_API_KEY
+        upsert_env_value(env_path, "KPTNCOOK_API_KEY", chosen_key)
+        rprint("Added KPTNCOOK_API_KEY to the .env file.")
+    else:
+        chosen_key = existing_api_key
+        rprint("KPTNCOOK_API_KEY is already set.")
+
+    if username_command:
+        upsert_env_value(env_path, "KPTNCOOK_USERNAME_COMMAND", username_command)
+        rprint("Stored KPTNCOOK_USERNAME_COMMAND in the .env file.")
+    if password_command:
+        upsert_env_value(env_path, "KPTNCOOK_PASSWORD_COMMAND", password_command)
+        rprint("Stored KPTNCOOK_PASSWORD_COMMAND in the .env file.")
+
+    if not fetch_access_token:
+        rprint("Skipping access token fetch.")
+        return
+
+    values = read_env_values(env_path)
+    username, password = get_credentials(
+        username_command or values.get("KPTNCOOK_USERNAME_COMMAND"),
+        password_command or values.get("KPTNCOOK_PASSWORD_COMMAND"),
+    )
+
+    if not username or not password:
+        rprint("[red]Failed to get credentials.[/red]")
+        sys.exit(1)
+
+    try:
+        access_token = _fetch_access_token(chosen_key, username, password)
+        upsert_env_value(env_path, "KPTNCOOK_ACCESS_TOKEN", access_token)
+        rprint("[green]✓ Access token retrieved successfully.[/green]")
+        rprint(f"Saved KPTNCOOK_ACCESS_TOKEN to {env_path}.")
+    except httpx.HTTPStatusError as exc:
+        detail = extract_http_error_message(exc.response)
+        if exc.response.status_code == 401:
+            message = (
+                "Login failed (HTTP 401). Check your email/password and make sure "
+                "KPTNCOOK_API_KEY is set to your real API key."
+            )
+        else:
+            message = f"HTTP {exc.response.status_code} while getting access token"
+            if detail:
+                message = f"{message}: {detail}"
+        rprint(f"[red]{message}[/red]")
+        sys.exit(1)
+    except httpx.HTTPError as exc:
+        rprint(f"[red]{format_request_error(exc)}[/red]")
+        sys.exit(1)

--- a/src/kptncook_setup/__init__.py
+++ b/src/kptncook_setup/__init__.py
@@ -1,123 +1,22 @@
 """
-Setup entrypoint for first-run configuration.
+Standalone ``kptncook-setup`` entry point.
+
+The implementation lives in :mod:`kptncook.setup`; this module only re-exports it
+so the console script keeps working while the same command is also available as
+``kptncook setup``. Keeping the implementation in the ``kptncook`` package avoids
+the import cycle that would arise if the main CLI imported ``kptncook_setup``.
 """
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
+from kptncook.setup import DEFAULT_API_URL, _fetch_access_token, cli, setup
+from kptncook.env import ENV_PATH, ENV_TEMPLATE
 
-import httpx
-import typer
-from rich import print as rprint
-
-from kptncook.api import KptnCookClient
-from kptncook.env import (
-    DEFAULT_API_KEY,
-    ENV_PATH,
-    ENV_TEMPLATE,
-    read_env_values,
-    scaffold_env_file,
-    upsert_env_value,
-)
-from kptncook.http_errors import extract_http_error_message, format_request_error
-from kptncook.password_manager import get_credentials
-
-DEFAULT_API_URL = "https://mobile.kptncook.com"
-__all__ = ["ENV_PATH", "ENV_TEMPLATE", "cli", "setup"]
-
-cli = typer.Typer()
-
-
-def _fetch_access_token(api_key: str, username: str, password: str) -> str:
-    client = KptnCookClient(
-        base_url=DEFAULT_API_URL, api_key=api_key, access_token=None
-    )
-    return client.get_access_token(username, password)
-
-
-@cli.command()
-def setup(
-    env_path: Path = typer.Option(
-        ENV_PATH, "--env-path", help="Path to the .env file to configure."
-    ),
-    api_key: str | None = typer.Option(
-        None,
-        "--api-key",
-        help="KptnCook API key (defaults to the value documented in README.md).",
-    ),
-    username_command: str | None = typer.Option(
-        None,
-        "--username-command",
-        help="Command to retrieve username from a password manager.",
-    ),
-    password_command: str | None = typer.Option(
-        None,
-        "--password-command",
-        help="Command to retrieve password from a password manager.",
-    ),
-    fetch_access_token: bool = typer.Option(
-        True,
-        "--fetch-access-token/--no-fetch-access-token",
-        help="Prompt for credentials and fetch an access token.",
-    ),
-) -> None:
-    """
-    Interactive setup for kptncook configuration.
-    """
-    scaffolded = scaffold_env_file(env_path)
-    if scaffolded:
-        rprint(f"Created {env_path} with a starter template.")
-
-    values = read_env_values(env_path)
-    existing_api_key = values.get("KPTNCOOK_API_KEY", "").strip()
-    if not existing_api_key:
-        chosen_key = api_key or DEFAULT_API_KEY
-        upsert_env_value(env_path, "KPTNCOOK_API_KEY", chosen_key)
-        rprint("Added KPTNCOOK_API_KEY to the .env file.")
-    else:
-        chosen_key = existing_api_key
-        rprint("KPTNCOOK_API_KEY is already set.")
-
-    if username_command:
-        upsert_env_value(env_path, "KPTNCOOK_USERNAME_COMMAND", username_command)
-        rprint("Stored KPTNCOOK_USERNAME_COMMAND in the .env file.")
-    if password_command:
-        upsert_env_value(env_path, "KPTNCOOK_PASSWORD_COMMAND", password_command)
-        rprint("Stored KPTNCOOK_PASSWORD_COMMAND in the .env file.")
-
-    if not fetch_access_token:
-        rprint("Skipping access token fetch.")
-        return
-
-    values = read_env_values(env_path)
-    username, password = get_credentials(
-        username_command or values.get("KPTNCOOK_USERNAME_COMMAND"),
-        password_command or values.get("KPTNCOOK_PASSWORD_COMMAND"),
-    )
-
-    if not username or not password:
-        rprint("[red]Failed to get credentials.[/red]")
-        sys.exit(1)
-
-    try:
-        access_token = _fetch_access_token(chosen_key, username, password)
-        upsert_env_value(env_path, "KPTNCOOK_ACCESS_TOKEN", access_token)
-        rprint("[green]✓ Access token retrieved successfully.[/green]")
-        rprint(f"Saved KPTNCOOK_ACCESS_TOKEN to {env_path}.")
-    except httpx.HTTPStatusError as exc:
-        detail = extract_http_error_message(exc.response)
-        if exc.response.status_code == 401:
-            message = (
-                "Login failed (HTTP 401). Check your email/password and make sure "
-                "KPTNCOOK_API_KEY is set to your real API key."
-            )
-        else:
-            message = f"HTTP {exc.response.status_code} while getting access token"
-            if detail:
-                message = f"{message}: {detail}"
-        rprint(f"[red]{message}[/red]")
-        sys.exit(1)
-    except httpx.HTTPError as exc:
-        rprint(f"[red]{format_request_error(exc)}[/red]")
-        sys.exit(1)
+__all__ = [
+    "DEFAULT_API_URL",
+    "ENV_PATH",
+    "ENV_TEMPLATE",
+    "_fetch_access_token",
+    "cli",
+    "setup",
+]

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,3 +1,5 @@
+import subprocess
+import sys
 from datetime import date
 from pathlib import Path
 from importlib import import_module
@@ -173,6 +175,29 @@ def test_access_token_command_saves_token_without_printing_it(monkeypatch, tmp_p
     assert "Saved KPTNCOOK_ACCESS_TOKEN to" in result.output
     assert str(env_path) in result.output.replace("\n", "")
     assert "secret-token-123" not in result.output
+
+
+def test_setup_is_registered_as_subcommand():
+    cli_module = import_module("kptncook.cli")
+
+    result = runner.invoke(cli_module.app, ["setup", "--help"])
+
+    assert result.exit_code == 0
+    assert "Interactive setup for kptncook configuration." in result.output
+
+
+def test_kptncook_setup_entrypoint_imports_without_cycle():
+    # The standalone `kptncook-setup` console script imports `kptncook_setup`
+    # before `kptncook`, which previously triggered a circular import. Use a
+    # fresh interpreter so the import order matches the entry point (in-process
+    # tests already have `kptncook` imported and cannot reproduce it).
+    result = subprocess.run(
+        [sys.executable, "-c", "import kptncook_setup; assert kptncook_setup.setup"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_discovery_list_save_command_smoke_uses_service_result(monkeypatch, minimal):

--- a/tests/env_test.py
+++ b/tests/env_test.py
@@ -1,8 +1,15 @@
 import os
 import stat
 
+from pathlib import Path
+
 from kptncook.env import ENV_TEMPLATE as MAIN_ENV_TEMPLATE
-from kptncook.env import read_env_values, scaffold_env_file, upsert_env_value
+from kptncook.env import (
+    _default_env_dir,
+    read_env_values,
+    scaffold_env_file,
+    upsert_env_value,
+)
 from kptncook_setup import ENV_TEMPLATE as SETUP_ENV_TEMPLATE
 
 
@@ -61,3 +68,21 @@ def test_upsert_env_value_tightens_permissions(tmp_path):
 
 def test_env_templates_are_kept_in_sync():
     assert MAIN_ENV_TEMPLATE == SETUP_ENV_TEMPLATE
+
+
+def test_default_env_dir_honors_kptncook_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("KPTNCOOK_HOME", str(tmp_path / "data"))
+
+    assert _default_env_dir() == tmp_path / "data"
+
+
+def test_default_env_dir_expands_kptncook_home(monkeypatch):
+    monkeypatch.setenv("KPTNCOOK_HOME", "~/kptncook-home")
+
+    assert _default_env_dir() == Path.home() / "kptncook-home"
+
+
+def test_default_env_dir_falls_back_to_home(monkeypatch):
+    monkeypatch.delenv("KPTNCOOK_HOME", raising=False)
+
+    assert _default_env_dir() == Path.home() / ".kptncook"


### PR DESCRIPTION
Fixes #87.

## Problem

The issue reporter hit a catch-22 in Docker:

- `docker run ... kptncook kptncook-access-token` fails with "Missing required configuration" and advises *"use `kptncook-setup` for guided setup."*
- `docker run ... kptncook kptncook-setup` fails with "No such command".

Two underlying bugs:

1. **`kptncook-setup` is a separate console script, not a `kptncook` subcommand.** The Docker image's `ENTRYPOINT ["kptncook"]` only dispatches `kptncook` subcommands, so the standalone binary is unreachable and the error message's advice is wrong for Docker users.
2. **`.env` ignored `KPTNCOOK_HOME`.** `ENV_PATH` was hardcoded to `~/.kptncook/.env`, while `Settings.root` honors `KPTNCOOK_HOME`. In Docker (`KPTNCOOK_HOME=/data`) the `.env` was written to an ephemeral `/root/.kptncook/.env` instead of the mounted `/data` volume, so config never persisted and the app read a different path than it wrote.

## Changes

- Expose guided setup as a `kptncook setup` subcommand (reachable through the Docker entrypoint); the standalone `kptncook-setup` still works.
- Move the setup implementation into `kptncook.setup` so the main CLI registers it without importing `kptncook_setup` — avoiding an import cycle that would otherwise break the standalone entrypoint. `kptncook_setup` now re-exports from `kptncook.setup`.
- Update the missing-config message to point at `kptncook setup`.
- Honor `KPTNCOOK_HOME` when locating `.env` so config lives alongside the rest of kptncook's data (and persists in the Docker volume).
- README: document `-e` as the primary Docker flow, interactive `kptncook setup` with `-it`, and the `KPTNCOOK_HOME`-based `.env` path.
- CHANGELOG entries.

## Tests

- `_default_env_dir()` honors / expands / falls back on `KPTNCOOK_HOME`.
- `kptncook setup` is registered as a subcommand.
- Subprocess test importing `kptncook_setup` first in a fresh interpreter, guarding against the import-cycle regression (in-process tests can't reproduce it).

`just check` passes (lint, mypy, 191 tests). Reviewed clean by a second model family.

## Note

`uv.lock` is stale on `main` (pinned to 0.0.32 while HEAD is the 0.0.33 release); any `uv run` regenerates it. Left out of this PR as unrelated — worth a separate housekeeping commit.